### PR TITLE
Support both GNU and Cray PrgEnv

### DIFF
--- a/DSVP/Makefile
+++ b/DSVP/Makefile
@@ -207,7 +207,11 @@ MPI_LINK = $(MPI_LINK_$(WRAP))
 #LINEAR ALGEBRA FLAGS:
 LA_LINK_ATLAS = -L$(PATH_BLAS_ATLAS) -lblas
 LA_LINK_OPENBLAS = -L$(PATH_BLAS_OPENBLAS) -lopenblas
+ifeq ($(TOOLKIT),GNU)
+LA_LINK_LIBSCI = -L$(PATH_BLAS_LIBSCI) -lsci_gnu_mp
+else
 LA_LINK_LIBSCI = -L$(PATH_BLAS_LIBSCI) -lsci_cray_mp
+endif
 ifeq ($(TOOLKIT),GNU)
 LA_LINK_MKL = -L$(PATH_BLAS_MKL) -lmkl_intel_lp64 -lmkl_core -lmkl_gnu_thread -lpthread -lm -ldl
 else

--- a/INTERVIRT/Makefile
+++ b/INTERVIRT/Makefile
@@ -207,7 +207,11 @@ MPI_LINK = $(MPI_LINK_$(WRAP))
 #LINEAR ALGEBRA FLAGS:
 LA_LINK_ATLAS = -L$(PATH_BLAS_ATLAS) -lblas
 LA_LINK_OPENBLAS = -L$(PATH_BLAS_OPENBLAS) -lopenblas
+ifeq ($(TOOLKIT),GNU)
+LA_LINK_LIBSCI = -L$(PATH_BLAS_LIBSCI) -lsci_gnu_mp
+else
 LA_LINK_LIBSCI = -L$(PATH_BLAS_LIBSCI) -lsci_cray_mp
+endif
 ifeq ($(TOOLKIT),GNU)
 LA_LINK_MKL = -L$(PATH_BLAS_MKL) -lmkl_intel_lp64 -lmkl_gnu_thread -lmkl_core -lpthread -lm -ldl
 else

--- a/INTRAVIRT/Makefile
+++ b/INTRAVIRT/Makefile
@@ -207,7 +207,11 @@ MPI_LINK = $(MPI_LINK_$(WRAP))
 #LINEAR ALGEBRA FLAGS:
 LA_LINK_ATLAS = -L$(PATH_BLAS_ATLAS) -lblas
 LA_LINK_OPENBLAS = -L$(PATH_BLAS_OPENBLAS) -lopenblas
+ifeq ($(TOOLKIT),GNU)
+LA_LINK_LIBSCI = -L$(PATH_BLAS_LIBSCI) -lsci_gnu_mp
+else
 LA_LINK_LIBSCI = -L$(PATH_BLAS_LIBSCI) -lsci_cray_mp
+endif
 ifeq ($(TOOLKIT),GNU)
 LA_LINK_MKL = -L$(PATH_BLAS_MKL) -lmkl_intel_lp64 -lmkl_gnu_thread -lmkl_core -lpthread -lm -ldl
 else

--- a/QFORCE/Makefile
+++ b/QFORCE/Makefile
@@ -207,7 +207,11 @@ MPI_LINK = $(MPI_LINK_$(WRAP))
 #LINEAR ALGEBRA FLAGS:
 LA_LINK_ATLAS = -L$(PATH_BLAS_ATLAS) -lblas
 LA_LINK_OPENBLAS = -L$(PATH_BLAS_OPENBLAS) -lopenblas
+ifeq ($(TOOLKIT),GNU)
+LA_LINK_LIBSCI = -L$(PATH_BLAS_LIBSCI) -lsci_gnu_mp
+else
 LA_LINK_LIBSCI = -L$(PATH_BLAS_LIBSCI) -lsci_cray_mp
+endif
 ifeq ($(TOOLKIT),GNU)
 LA_LINK_MKL = -L$(PATH_BLAS_MKL) -lmkl_intel_lp64 -lmkl_gnu_thread -lmkl_core -lpthread -lm -ldl
 else

--- a/TALSH/Makefile
+++ b/TALSH/Makefile
@@ -246,7 +246,11 @@ MPI_LINK = $(MPI_LINK_$(WRAP))
 #LINEAR ALGEBRA FLAGS:
 LA_LINK_ATLAS = -L$(PATH_BLAS_ATLAS) -lblas
 LA_LINK_OPENBLAS = -L$(PATH_BLAS_OPENBLAS) -lopenblas
+ifeq ($(TOOLKIT),GNU)
+LA_LINK_LIBSCI = -L$(PATH_BLAS_LIBSCI) -lsci_gnu_mp
+else
 LA_LINK_LIBSCI = -L$(PATH_BLAS_LIBSCI) -lsci_cray_mp
+endif
 ifeq ($(TOOLKIT),GNU)
 LA_LINK_MKL = -L$(PATH_BLAS_MKL) -lmkl_intel_lp64 -lmkl_gnu_thread -lmkl_core -lpthread -lm -ldl
 else


### PR DESCRIPTION
Changing the name of `libsci` depending on the compiler toolkit.

This will enable users to compile with both PrgEnv-cray and PrgEnv-gnu.

I'll have another PR on ExaTN to support LIBSCI from ExaTN but it'll depend on this one being merged.